### PR TITLE
Better hiding sensitive data (& small other things)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.js	text eol=lf
+*.json	text eol=lf
+*.html	text eol=lf

--- a/addon/addon-ui.js
+++ b/addon/addon-ui.js
@@ -16,11 +16,12 @@ save = function() {
 function load (data) {
     if (data && data.prefs) {
         algorithmInput.value = data.prefs.algorithm || UniquePasswordBuilder.SCRYPT;
+        hideSensitiveData.checked = data.prefs.hideSensitiveData;
+        hideData();
         changeAlgorithm();
         difficultyScryptInput.value = data.prefs.difficulty || "8192";
         difficultyArgon2Input.value = data.prefs.difficultyArgon2 || 10;
         usersaltInput.value = data.prefs.usersalt || '';
-        hideSensitiveData.checked = data.prefs.hideSensitiveData;
         data.prefs.options && optionsDiv.classList.remove('hidden');
     } else {
         algorithmInput.value = UniquePasswordBuilder.SCRYPT;

--- a/src/common-ui.js
+++ b/src/common-ui.js
@@ -33,9 +33,13 @@ var hideData = function() {
     if (hideSensitiveData.checked) {
         passwordIconMemo.classList.add('hidden');
         outputField.classList.add('hide');
+        usersaltInput.classList.add('hide');
     } else {
         outputField.classList.remove('hide');
-        UniquePasswordBuilder.displayIcons(passwordInput.value, passwordIconMemo);
+        usersaltInput.classList.remove('hide');
+        if(passwordInput.value !== '') {
+            UniquePasswordBuilder.displayIcons(passwordInput.value, passwordIconMemo);
+        }
     }
 };
 
@@ -129,4 +133,3 @@ usersaltInput.addEventListener('change', compute, false);
 hideSensitiveData.addEventListener('change', hideData, false);
 optionsLink.addEventListener('click', toggleOptions, false);
 copyToClipboardBtn.addEventListener('click', copyToClipboard, false);
-

--- a/src/page/index.html
+++ b/src/page/index.html
@@ -126,9 +126,10 @@
                 var load = function() {
                     algorithmInput.value = localStorage.algorithm || UniquePasswordBuilder.SCRYPT;
                     difficultyScryptInput.value = localStorage.difficulty || 8192;
+                    hideSensitiveData.checked = localStorage.hideSensitiveData === 'true';
+                    hideData();
                     if (localStorage.difficultyArgon2) difficultyArgon2Input.value = localStorage.difficultyArgon2 | 10;
                     if (localStorage.usersalt) usersaltInput.value = localStorage.usersalt;
-                    hideSensitiveData.checked = localStorage.hideSensitiveData === 'true';
                     if(localStorage.options === 'true') optionsDiv.classList.remove('hidden');
                     changeAlgorithm();
                 }

--- a/src/page/index.html
+++ b/src/page/index.html
@@ -129,7 +129,7 @@
                     if (localStorage.difficultyArgon2) difficultyArgon2Input.value = localStorage.difficultyArgon2 | 10;
                     if (localStorage.usersalt) usersaltInput.value = localStorage.usersalt;
                     hideSensitiveData.checked = localStorage.hideSensitiveData === 'true';
-                    localStorage.options && optionsDiv.classList.remove('hidden');
+                    if(localStorage.options === 'true') optionsDiv.classList.remove('hidden');
                     changeAlgorithm();
                 }
 

--- a/src/templates/form.html
+++ b/src/templates/form.html
@@ -11,7 +11,14 @@
             />
         </label>
         <label id="usefulUrl" class="small"></label>
-        <a href="" class="options">options</a>
+        <label class="checkbox">
+            <div>
+                Hide sensitive data:&nbsp;
+                <input type="checkbox" id="hideSensitiveData" />
+            </div>
+            <a href="" class="options">options</a>
+        </label>
+        
         <div class="options hidden">
             <label>Algorithm:
                 <select id="algorithm">
@@ -38,9 +45,6 @@
             </label>
             <label>User salt:
                 <input type="text" id="usersalt" value="" maxlength="80" />
-            </label>
-            <label class="checkbox">Hide sensitive data:&nbsp;
-                <input type="checkbox" id="hideSensitiveData" />
             </label>
         </div>
         <label>

--- a/src/templates/styles.css
+++ b/src/templates/styles.css
@@ -1,6 +1,6 @@
 fieldset                  { border: 1px solid black; background-color: #70b1e254; padding: .5em; }
 label                     { display: flex; margin: .25em; align-items: center; }
-label.checkbox            { display: block; }
+label.checkbox            { justify-content: space-between; }
 input, select, #output    { margin-left: .25em; flex-grow: 1; }
 input, select             { padding: 4px; line-height: 1.25em; color: #555; border: 1px solid #CCC; border-radius: 3px; background-color: white; }
 input                     { height: 18px; }
@@ -13,5 +13,5 @@ input[type="checkbox"]    { vertical-align:middle; margin-left: auto;}
 #output                   { font-family: monospace; border: 1px dashed black; padding: .5em .1em 0 .1em; text-align: center; background: white; color: black; font-weight: bold; font-size: 1.2em; }
 #output.hide              { background-color: black; }
 #output.error.hide        { background-color: none; }
-a.options                 { text-align: right; color: #5b93be; display: block; margin: 0 0 .5em 0; }
+a.options                 { color: #5b93be; }
 i#copyToClipboardBtn      { color: #5b93be; font-size: 32px; margin: 0 0 0 5px;}

--- a/src/templates/styles.css
+++ b/src/templates/styles.css
@@ -15,4 +15,4 @@ input[type="checkbox"]    { vertical-align:middle; margin-left: auto;}
 #output.hide              { background-color: black; }
 #output.error.hide        { background-color: none; }
 a.options                 { color: #5b93be; }
-i#copyToClipboardBtn      { color: #5b93be; font-size: 32px; margin: 0 0 0 5px;}
+i#copyToClipboardBtn      { color: #5b93be; font-size: 26px; margin: 0 0 0 5px;}

--- a/src/templates/styles.css
+++ b/src/templates/styles.css
@@ -5,6 +5,7 @@ input, select, #output    { margin-left: .25em; flex-grow: 1; }
 input, select             { padding: 4px; line-height: 1.25em; color: #555; border: 1px solid #CCC; border-radius: 3px; background-color: white; }
 input                     { height: 18px; }
 input:focus, select:focus { border-color: #72B5E8; box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset, 0px 0px 8px rgba(82, 168, 236, 0.6); outline: 0px none; }
+input.hide                { background-color: black; color: black;}
 .small                    { font-size: 11px; }
 .error                    { border: 2px solid #F22; color: #F22; font-weight: bold; }
 .icons                    { margin: 0 0 0 5px; display: flex; justify-content: space-between; }


### PR DESCRIPTION
* Move "Hide sensitive data" checkbox out of options block (because that's not an algo parameter and we should immediatly see if the option is checked)
* Hide also the salt field (it's also a sensitive data)
* fix restore of 'option' setting (hide 'options' fields) that was broken
* 'Copy password' icon slightly smaller... (more beautiful) 
* .gitattributes to better manage end of lines
